### PR TITLE
fix compute units calculation

### DIFF
--- a/src/solana_transactor/ix_compiler.rs
+++ b/src/solana_transactor/ix_compiler.rs
@@ -142,7 +142,7 @@ impl IxCompiler {
         }
         self.ix_buffer.push(ix);
         self.address_lookup_table_accounts.extend_from_slice(address_lookup_table_accounts);
-        self.total_compute_units += total_compute_units;
+        self.total_compute_units = total_compute_units;
         Ok(None)
     }
 


### PR DESCRIPTION
When running the tests with the same instruction that takes 20k CU, there was an accumulation error.

before:

```
[2024-12-10T13:04:57Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 0 Tx len: 329 CU: 20000
[2024-12-10T13:04:57Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 1 Tx len: 471 CU: 40000
[2024-12-10T13:04:57Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 2 Tx len: 613 CU: 80000
[2024-12-10T13:04:57Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 3 Tx len: 755 CU: 160000
[2024-12-10T13:04:57Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 4 Tx len: 897 CU: 320000
[2024-12-10T13:04:57Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 5 Tx len: 1039 CU: 640000
[2024-12-10T13:04:57Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 6 Tx len: 1181 CU: 1280000
```


after:

```
[2024-12-10T13:04:13Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 0 Tx len: 329 CU: 20000
[2024-12-10T13:04:13Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 1 Tx len: 471 CU: 40000
[2024-12-10T13:04:13Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 2 Tx len: 613 CU: 60000
[2024-12-10T13:04:13Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 3 Tx len: 755 CU: 80000
[2024-12-10T13:04:13Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 4 Tx len: 897 CU: 100000
[2024-12-10T13:04:13Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 5 Tx len: 1039 CU: 120000
[2024-12-10T13:04:13Z DEBUG solana_tools::solana_transactor::ix_compiler] Instructions: 6 Tx len: 1181 CU: 140000
```